### PR TITLE
Updated JDA to 5.0.0-beta.6 per jda message:

### DIFF
--- a/audio/src/main/groovy/com/asm/tavern/discord/audio/LavaPlayerAudioService.groovy
+++ b/audio/src/main/groovy/com/asm/tavern/discord/audio/LavaPlayerAudioService.groovy
@@ -14,7 +14,7 @@ import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.GuildVoiceState
-import net.dv8tion.jda.api.entities.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.managers.AudioManager
 import org.slf4j.ext.XLogger
 import org.slf4j.ext.XLoggerFactory

--- a/buildSrc/src/main/groovy/com.asm.tavern.discord.groovy-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.asm.tavern.discord.groovy-common-conventions.gradle
@@ -31,7 +31,7 @@ dependencies {
     compile group: 'org.springframework', name: 'spring-beans', version: '5.3.3'
 
     // Discord JDS API
-    compile 'net.dv8tion:JDA:4.4.0_352'
+    compile 'net.dv8tion:JDA:5.0.0-beta.6'
 
     // Logging
     compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/Discord.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/Discord.groovy
@@ -6,6 +6,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.entities.Activity
+import net.dv8tion.jda.api.requests.GatewayIntent
 import org.slf4j.ext.XLogger
 import org.slf4j.ext.XLoggerFactory
 
@@ -32,6 +33,7 @@ class Discord {
 					.setActivity(Activity.listening("Beer"))
 					.setEventPool(Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("JDA Thread %d").build()))
 					.addEventListeners(new DiscordListener(commandParser, commandHandlerRegistry))
+					.enableIntents(GatewayIntent.MESSAGE_CONTENT, GatewayIntent.GUILD_MEMBERS)
 					.build()
 		}
 	}

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/DiscordListener.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/DiscordListener.groovy
@@ -7,8 +7,9 @@ import com.asm.tavern.domain.model.command.CommandHandlerRegistry
 import com.asm.tavern.domain.model.command.CommandMessage
 import com.asm.tavern.domain.model.discord.GuildId
 import com.asm.tavern.domain.model.discord.VoiceChannelId
-import net.dv8tion.jda.api.events.guild.voice.GuildVoiceLeaveEvent
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.guild.voice.GuildVoiceUpdateEvent
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import net.dv8tion.jda.api.hooks.ListenerAdapter
 import net.dv8tion.jda.api.events.interaction.*
 import org.slf4j.ext.XLogger
@@ -28,7 +29,7 @@ class DiscordListener extends ListenerAdapter {
 	}
 
 	@Override
-	void onGuildMessageReceived(@Nonnull GuildMessageReceivedEvent event) {
+	void onMessageReceived(@Nonnull MessageReceivedEvent event) {
 		String message = event.getMessage().getContentRaw().trim()
 		CommandMessage result = parser.parse(message)
 
@@ -58,7 +59,7 @@ class DiscordListener extends ListenerAdapter {
 	}
 
 	@Override
-	void onGuildVoiceLeave(@Nonnull GuildVoiceLeaveEvent event) {
+	void onGuildVoiceUpdate(@Nonnull GuildVoiceUpdateEvent event) {
 		// Leave if everyone else leaves the chat
 		GuildId guildId = new GuildId(event.getGuild().getId())
 		VoiceChannelId voiceChannelId = new VoiceChannelId(event.getChannelLeft().getId())
@@ -69,7 +70,7 @@ class DiscordListener extends ListenerAdapter {
 	}
 
 	@Override
-	void onButtonClick(@Nonnull ButtonClickEvent event) {
+	void onButtonInteraction(@Nonnull ButtonInteractionEvent event) {
 		String message = event.getButton().id
 		CommandMessage result = parser.parse(parser.prefix + message)
 		event.deferEdit().queue()
@@ -84,7 +85,7 @@ class DiscordListener extends ListenerAdapter {
 
 			CommandHandler handler = commandHandlerRegistry.getHandler(result)
 			if (handler) {
-				if (!handler.handle(new GuildMessageReceivedEvent(event.getJDA(), event.responseNumber, event.getMessage()), result)) {
+				if (!handler.handle(new MessageReceivedEvent(event.getJDA(), event.responseNumber, event.getMessage()), result)) {
 					logger.error("Failed to handle command ${parser.prefix}${result.getCommandString()}")
 				}
 			} else {

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/AddSongCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/AddSongCommandHandler.groovy
@@ -4,7 +4,7 @@ import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.SongId
 import com.asm.tavern.domain.model.audio.SongService
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -26,7 +26,7 @@ class AddSongCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		String id = message.args[1]
 		String uri = message.args[2]
 

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/AddSongWithCategoryCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/AddSongWithCategoryCommandHandler.groovy
@@ -4,7 +4,7 @@ import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.SongId
 import com.asm.tavern.domain.model.audio.SongService
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -26,7 +26,7 @@ class AddSongWithCategoryCommandHandler implements CommandHandler {
     }
 
     @Override
-    CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+    CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
         String id = message.args[1]
         String uri = message.args[2]
         String category = message.args[3]

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/ClearCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/ClearCommandHandler.groovy
@@ -4,7 +4,7 @@ import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.discord.GuildId
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -26,7 +26,7 @@ class ClearCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		audioService.clear(new GuildId(event.getGuild().getId()))
 		event.getChannel().sendMessage("Cleared song queue").queue()
 		new CommandResultBuilder().success().build()

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/JoinCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/JoinCommandHandler.groovy
@@ -4,7 +4,7 @@ package com.asm.tavern.discord.discord.audio
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -26,7 +26,7 @@ class JoinCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
 		new CommandResultBuilder().success().build()
 	}

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/LeaveCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/LeaveCommandHandler.groovy
@@ -4,7 +4,7 @@ package com.asm.tavern.discord.discord.audio
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -26,7 +26,7 @@ class LeaveCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		audioService.leave(event.getGuild())
 		new CommandResultBuilder().success().build()
 	}

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/NowPlayingCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/NowPlayingCommandHandler.groovy
@@ -7,8 +7,8 @@ import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.discord.GuildId
 import net.dv8tion.jda.api.EmbedBuilder
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
-import net.dv8tion.jda.api.interactions.components.Button
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+import net.dv8tion.jda.api.interactions.components.buttons.Button
 import net.dv8tion.jda.api.interactions.components.*
 
 import javax.annotation.Nonnull
@@ -34,7 +34,7 @@ class NowPlayingCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		ActiveAudioTrack track = audioService.getNowPlaying(new GuildId(event.getGuild().getId()))
 
 		Function<Duration, String> formatTime = (Duration duration) -> {

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PauseCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PauseCommandHandler.groovy
@@ -5,7 +5,7 @@ import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.discord.GuildId
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -27,7 +27,7 @@ class PauseCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
         GuildId guildId = new GuildId(event.getGuild().getId())
         if(!audioService.getIsPaused(guildId)){
             audioService.pause(guildId)

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PlayCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PlayCommandHandler.groovy
@@ -6,7 +6,7 @@ import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.audio.SongService
 import com.asm.tavern.domain.model.audio.SpotifyService
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -32,7 +32,7 @@ class PlayCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		String songId = message.args.first()
 
 		//Check for spotify link here so we can play multiple times for a playlist from spotify
@@ -40,7 +40,7 @@ class PlayCommandHandler implements CommandHandler {
             spotifyService.getListOfSongsFromURL(songId).ifPresentOrElse( songList -> {
                 audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
                 songList.stream()
-                        .forEach(song -> audioService.play(event.getChannel(), song.id.toString()))
+                        .forEach(song -> audioService.play(event.getChannel().asTextChannel(), song.id.toString()))
 
             }, () -> {
                 event.getChannel().sendMessage("Could not retrieve spotify songs from ${songId}")
@@ -49,11 +49,11 @@ class PlayCommandHandler implements CommandHandler {
         else{
             songService.songFromString(songId).ifPresentOrElse(song -> {
                 audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
-                audioService.playNext(event.getChannel(), song.uri)
+                audioService.playNext(event.getChannel().asTextChannel(), song.uri)
             }, () -> {
                 // this will search the message on youtube
                 audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
-                audioService.play(event.getChannel(), message.args.join(" "))
+                audioService.play(event.getChannel().asTextChannel(), message.args.join(" "))
             })
         }
 		new CommandResultBuilder().success().build()

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PlayNextCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PlayNextCommandHandler.groovy
@@ -5,7 +5,7 @@ import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.audio.SongService
 import com.asm.tavern.domain.model.audio.SpotifyService
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -31,7 +31,7 @@ class PlayNextCommandHandler implements CommandHandler {
     }
 
     @Override
-    CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+    CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
         String songId = message.args.first()
 
         //Check for spotify link here so we can play multiple times for a playlist from spotify
@@ -39,7 +39,7 @@ class PlayNextCommandHandler implements CommandHandler {
             spotifyService.getListOfSongsFromURL(songId).ifPresentOrElse( songList -> {
                 audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
                 songList.stream()
-                        .forEach(song -> audioService.playNext(event.getChannel(), song.id.toString()))
+                        .forEach(song -> audioService.playNext(event.getChannel().asTextChannel(), song.id.toString()))
 
             }, () -> {
                 event.getChannel().sendMessage("Could not retrieve spotify songs from ${songId}")
@@ -48,11 +48,11 @@ class PlayNextCommandHandler implements CommandHandler {
         else{
             songService.songFromString(songId).ifPresentOrElse(song -> {
                 audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
-                audioService.playNext(event.getChannel(), song.uri)
+                audioService.playNext(event.getChannel().asTextChannel(), song.uri)
             }, () -> {
                 // this will search the message on youtube
                 audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
-                audioService.playNext(event.getChannel(), message.args.join(" "))
+                audioService.playNext(event.getChannel().asTextChannel(), message.args.join(" "))
             })
         }
         new CommandResultBuilder().success().build()

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/QueueCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/QueueCommandHandler.groovy
@@ -7,7 +7,7 @@ import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.audio.AudioTrackInfo
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.discord.GuildId
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import org.slf4j.ext.XLogger
 import org.slf4j.ext.XLoggerFactory
 import java.time.Duration
@@ -34,7 +34,7 @@ class QueueCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		List<AudioTrackInfo> queue = audioService.getQueue(new GuildId(event.getGuild().getId()))
 		logger.debug("The queue has ${queue.size()} tracks")
 		if (!queue.isEmpty()) {

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/RemoveSongCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/RemoveSongCommandHandler.groovy
@@ -4,7 +4,7 @@ import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.SongId
 import com.asm.tavern.domain.model.audio.SongService
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -26,7 +26,7 @@ class RemoveSongCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		String id = message.args[1]
 		songService.remove(new SongId(id))
 		event.getChannel().sendMessage("Removed song ${id}").queue()

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/ShuffleQueueCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/ShuffleQueueCommandHandler.groovy
@@ -8,7 +8,7 @@ import com.asm.tavern.domain.model.command.CommandHandler
 import com.asm.tavern.domain.model.command.CommandMessage
 import com.asm.tavern.domain.model.command.CommandResult
 import com.asm.tavern.domain.model.discord.GuildId
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -30,7 +30,7 @@ class ShuffleQueueCommandHandler implements CommandHandler {
     }
 
     @Override
-    CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+    CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
         audioService.shuffle(new GuildId(event.guild.id))
         event.getChannel().sendMessage("Shuffled the queue!").queue()
     }

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/SkipCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/SkipCommandHandler.groovy
@@ -5,7 +5,7 @@ import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.discord.GuildId
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -27,7 +27,7 @@ class SkipCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		int skipAmount = message.args[0] ? Integer.parseInt(message.args[0]) : 1
 		GuildId guildId = new GuildId(event.getGuild().getId())
 		String title = audioService.getNowPlaying(guildId).info.title

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/SongsCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/SongsCommandHandler.groovy
@@ -6,7 +6,7 @@ import com.asm.tavern.domain.model.audio.Song
 import com.asm.tavern.domain.model.audio.SongService
 import com.asm.tavern.domain.model.command.*
 import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 import java.util.function.Function
@@ -31,13 +31,13 @@ class SongsCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		int chunkSize = 10
 		String currentCategory = ""
 
 		// Function for pushing message so message can be pushed when max chunk size to avoid discord max message length. Also empty builder when pushed
 		Function<StringBuilder, String> pushMessage = (StringBuilder builder) -> {
-			event.getChannel().sendMessage(new MessageEmbed(null, "${currentCategory} Songs", builder.toString(), null, null, 0xFF0000, null, null, null, null, null,null, null)).queue()
+			event.getChannel().asTextChannel().sendMessageEmbeds(new MessageEmbed(null, "${currentCategory} Songs", builder.toString(), null, null, 0xFF0000, null, null, null, null, null,null, null)).queue()
 			builder.setLength(0)
 		}
 

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/StopCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/StopCommandHandler.groovy
@@ -5,7 +5,7 @@ import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.discord.GuildId
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -27,7 +27,7 @@ class StopCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		audioService.stop(new GuildId(event.getGuild().getId()))
 		new CommandResultBuilder().success().build()
 	}

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/UnpauseCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/UnpauseCommandHandler.groovy
@@ -5,7 +5,7 @@ import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.audio.AudioService
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.discord.GuildId
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -27,7 +27,7 @@ class UnpauseCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		audioService.unpause(new GuildId(event.getGuild().getId()))
 		GuildId guildId = new GuildId(event.getGuild().getId())
 		String title = audioService.getNowPlaying(guildId).info.title

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/ComradeCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/ComradeCommandHandler.groovy
@@ -11,7 +11,7 @@ import com.asm.tavern.domain.model.command.CommandResultBuilder
 import com.asm.tavern.domain.model.drinks.ComradeService
 import net.dv8tion.jda.api.entities.EmbedType
 import net.dv8tion.jda.api.entities.MessageEmbed
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 import java.time.OffsetDateTime
@@ -36,7 +36,7 @@ class ComradeCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		comradeService.enable()
 		MessageEmbed embeddedImage = new MessageEmbed(
 				"https://media3.giphy.com/media/befaYZCgtZfZm/giphy.gif",
@@ -52,10 +52,10 @@ class ComradeCommandHandler implements CommandHandler {
 				null,
 				new MessageEmbed.ImageInfo("https://media3.giphy.com/media/befaYZCgtZfZm/giphy.gif", "https://media3.giphy.com/media/befaYZCgtZfZm/giphy.gif", 400, 300),
 				null)
-		event.getChannel().sendMessage(embeddedImage).queue()
+		event.getChannel().asTextChannel().sendMessageEmbeds(embeddedImage).queue()
 		event.getGuild().getSelfMember().modifyNickname("Comrade Bot").submit()
 		audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
-		audioService.play(event.getChannel(), URI.create("https://www.youtube.com/watch?v=bCBJ-MaUTC4&ab_channel=ChornyyBaron"))
+		audioService.play(event.getChannel().asTextChannel(), URI.create("https://www.youtube.com/watch?v=bCBJ-MaUTC4&ab_channel=ChornyyBaron"))
 		new CommandResultBuilder().success().build()
 	}
 

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/DrinkCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/DrinkCommandHandler.groovy
@@ -7,7 +7,7 @@ import com.asm.tavern.domain.model.discord.Mention
 import com.asm.tavern.domain.model.drinks.DrinkService
 import com.asm.tavern.domain.model.drinks.MemberDrinkResult
 import net.dv8tion.jda.api.entities.Member
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 import java.util.stream.Collectors
@@ -30,7 +30,7 @@ class DrinkCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		List<Member> members = DiscordUtils.getUsersVoiceChannel(event.getJDA(), event.getAuthor().id)
 				.map(channel -> channel.getMembers())
 				.orElse([])

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/DrinksCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/DrinksCommandHandler.groovy
@@ -7,7 +7,7 @@ import com.asm.tavern.domain.model.discord.Mention
 import com.asm.tavern.domain.model.discord.UserId
 import com.asm.tavern.domain.model.drinks.DrinkService
 import net.dv8tion.jda.api.entities.Member
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 import java.util.stream.Collectors
@@ -30,7 +30,7 @@ class DrinksCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		List<Member> members = DiscordUtils.getUsersVoiceChannel(event.getJDA(), event.getMember().id)
 				.map(channel -> channel.members)
 				.orElse([event.getMember()])

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/PopPopCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/PopPopCommandHandler.groovy
@@ -7,7 +7,7 @@ import com.asm.tavern.domain.model.discord.Mention
 import com.asm.tavern.domain.model.drinks.DrinkService
 import com.asm.tavern.domain.model.drinks.MemberDrinkResult
 import net.dv8tion.jda.api.entities.Member
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 import java.util.stream.Collectors
@@ -30,10 +30,10 @@ class PopPopCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		DiscordUtils.getUsersVoiceChannel(event.getJDA(), event.getAuthor().id)
 				.map(channel -> {
-					List<MemberDrinkResult> results = drinkService.popPop(channel.members)
+					List<MemberDrinkResult> results = drinkService.popPop(channel.getMembers())
 					if (results[0].shot) {
 						event.getChannel().sendMessage("Pop Pop!\nSucks to suck. Everyone take a shot!").queue()
 					} else {

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/UncomradeCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/drinks/UncomradeCommandHandler.groovy
@@ -3,7 +3,7 @@ package com.asm.tavern.discord.discord.drinks
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.drinks.ComradeService
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -25,7 +25,7 @@ class UncomradeCommandHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		comradeService.disable()
 		event.getGuild().getSelfMember().modifyNickname(null).submit()
 		new CommandResultBuilder().success().build()

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/help/CommandHelpHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/help/CommandHelpHandler.groovy
@@ -3,7 +3,7 @@ package com.asm.tavern.discord.discord.help
 import com.asm.tavern.discord.discord.command.parser.CommandParser
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import org.slf4j.ext.XLogger
 import org.slf4j.ext.XLoggerFactory
 
@@ -28,7 +28,7 @@ class CommandHelpHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		String commandMessage = "${commandParser.prefix}${String.join(" ", message.args)}"
 		CommandMessage commandToHelpWith = commandParser.getCommandFromMessage(commandMessage)
 		if (commandToHelpWith.commandList.isEmpty()) {

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/help/HelpHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/help/HelpHandler.groovy
@@ -9,7 +9,7 @@ import com.asm.tavern.domain.model.command.CommandResult
 import com.asm.tavern.domain.model.command.CommandResultBuilder
 import com.asm.tavern.domain.model.help.CommandIniPrinter
 import net.dv8tion.jda.api.entities.Message
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -31,7 +31,7 @@ class HelpHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		event.getChannel().sendMessage(new CommandIniPrinter().print(prefix, TavernCommands.getCommands())).queue()
 		return new CommandResultBuilder().success().build()
 	}

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/AmountAndSidesRollHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/AmountAndSidesRollHandler.groovy
@@ -4,7 +4,7 @@ package com.asm.tavern.discord.discord.roll
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.roll.RollService
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import org.slf4j.ext.XLogger
 import org.slf4j.ext.XLoggerFactory
 
@@ -30,7 +30,7 @@ class AmountAndSidesRollHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		try {
 			int amount = Integer.parseInt(message.args.first())
 			int sides = Integer.parseInt(message.args.last())

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/AmountXSidesHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/AmountXSidesHandler.groovy
@@ -4,14 +4,14 @@ package com.asm.tavern.discord.discord.roll
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.roll.RollService
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import org.slf4j.ext.XLogger
 import org.slf4j.ext.XLoggerFactory
 
 import javax.annotation.Nonnull
 
 class AmountXSidesHandler implements CommandHandler {
-	private static final XLogger logger = XLoggerFactory.getXLogger(AmountXSidesHandler.class);
+	private static final XLogger logger = XLoggerFactory.getXLogger(AmountXSidesHandler.class)
 
 	private final RollService rollService
 
@@ -30,7 +30,7 @@ class AmountXSidesHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		try {
 			String[] amountAndSides = message.args[0].toLowerCase().split('x')
 			int amount = Integer.parseInt(amountAndSides[0])

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/DefaultRollHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/DefaultRollHandler.groovy
@@ -4,7 +4,7 @@ package com.asm.tavern.discord.discord.roll
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.roll.RollService
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 import org.slf4j.ext.XLogger
 import org.slf4j.ext.XLoggerFactory
 
@@ -30,7 +30,7 @@ class DefaultRollHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		int roll = rollService.rollSingle(6)
 		event.getChannel().sendMessage("You rolled a " + roll).queue({-> logger.trace('Sent default roll result')}, {-> logger.error('Failed to send default roll result')})
 		return new CommandResultBuilder().success().build()

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/RollTideHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/RollTideHandler.groovy
@@ -2,7 +2,7 @@ package com.asm.tavern.discord.discord.roll
 
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.command.*
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -19,7 +19,7 @@ class RollTideHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		event.getChannel().sendMessage('What are you doing step bro!?').queue()
 		return new CommandResultBuilder().success().build()
 	}

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/SidesRollHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/roll/SidesRollHandler.groovy
@@ -4,7 +4,7 @@ package com.asm.tavern.discord.discord.roll
 import com.asm.tavern.domain.model.TavernCommands
 import com.asm.tavern.domain.model.command.*
 import com.asm.tavern.domain.model.roll.RollService
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -26,7 +26,7 @@ class SidesRollHandler implements CommandHandler {
 	}
 
 	@Override
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message) {
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		try {
 			int sides = Integer.parseInt(message.args.first())
 			int roll = rollService.rollSingle(sides)

--- a/domain/src/main/groovy/com/asm/tavern/domain/model/audio/AudioService.groovy
+++ b/domain/src/main/groovy/com/asm/tavern/domain/model/audio/AudioService.groovy
@@ -4,7 +4,7 @@ import com.asm.tavern.domain.model.discord.GuildId
 import com.asm.tavern.domain.model.discord.VoiceChannelId
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.GuildVoiceState
-import net.dv8tion.jda.api.entities.TextChannel
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
 import net.dv8tion.jda.api.managers.AudioManager
 
 interface AudioService {

--- a/domain/src/main/groovy/com/asm/tavern/domain/model/command/CommandHandler.groovy
+++ b/domain/src/main/groovy/com/asm/tavern/domain/model/command/CommandHandler.groovy
@@ -1,7 +1,7 @@
 package com.asm.tavern.domain.model.command
 
-import net.dv8tion.jda.api.events.interaction.ButtonClickEvent
-import net.dv8tion.jda.api.events.message.guild.GuildMessageReceivedEvent
+import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
 
 import javax.annotation.Nonnull
 
@@ -26,14 +26,14 @@ interface CommandHandler {
 	 * @param args arguments for the command invocation
 	 * @return result of the command
 	 */
-	CommandResult handle(@Nonnull GuildMessageReceivedEvent event, CommandMessage message)
+	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message)
 	/**
 	 * Handle the invocation of the command
 	 * @param event the discord event
 	 * @param args arguments for the command invocation
 	 * @return result of the command
 	 */
-	default CommandResult handle(@Nonnull ButtonClickEvent event, CommandMessage message){
+	default CommandResult handle(@Nonnull ButtonInteractionEvent event, CommandMessage message){
 		new CommandResultBuilder().success().build()
 	}
 }

--- a/utilities/src/main/groovy/com/asm/tavern/discord/utilities/DiscordUtils.groovy
+++ b/utilities/src/main/groovy/com/asm/tavern/discord/utilities/DiscordUtils.groovy
@@ -1,7 +1,7 @@
 package com.asm.tavern.discord.utilities
 
 import net.dv8tion.jda.api.JDA
-import net.dv8tion.jda.api.entities.VoiceChannel
+import net.dv8tion.jda.api.entities.channel.concrete.VoiceChannel
 
 class DiscordUtils {
 
@@ -12,7 +12,7 @@ class DiscordUtils {
 	static Optional<VoiceChannel> getUsersVoiceChannel(JDA jda, String userId) {
 		return jda.getVoiceChannels().stream()
 				.filter(channel -> channel.getMembers().stream()
-						.anyMatch(member -> member.getUser().getId() == userId)).findFirst();
+						.anyMatch(member -> member.getUser().getId() == userId)).findFirst()
 	}
 
 }


### PR DESCRIPTION
    Discord is rolling out a breaking change to audio connections today. Everyone who makes use of audio connections should update to the latest version of JDA. Affected bots will struggle connecting to channels, resulting in join/leave loops.

    For people using v5 (recommended), update to 5.0.0-beta.6 or later.
    The fix has been backported to v4 (legacy) with 4.4.1_353, however we recommend updating to v5 as soon as possible.

 Updated all references to classes and methods to point to new method/class used in jda 5.0.0-beta.6

 Added a retry attempt to the trackscheduler that attempts to replay the track that had an exception 3 times before skipping. This should fix when youtube incorrectly responds that a video is unavailable