### PR TITLE
Walkyst version -> to lavalink-devs org location

### DIFF
--- a/audio/build.gradle
+++ b/audio/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     implementation project(':utilities')
     // Repo abandoned: implementation 'com.sedmelluq:lavaplayer:1.3.61'
     // Using for (walkyst) instead
-    implementation 'com.github.walkyst:lavaplayer-fork:1.4.0'
+    implementation 'dev.arbjerg:lavaplayer:2.0.0'
 }
 


### PR DESCRIPTION
Update to new lavalink-dev and to 2.0.0 version of lavaplayer to fix playback errors with youtube changes.