### PR TITLE
Play mode additions.

### DIFF
--- a/audio/src/main/groovy/com/asm/tavern/discord/audio/ModeService.groovy
+++ b/audio/src/main/groovy/com/asm/tavern/discord/audio/ModeService.groovy
@@ -1,0 +1,87 @@
+package com.asm.tavern.discord.audio
+
+import com.asm.tavern.domain.model.audio.AudioService
+import com.asm.tavern.domain.model.audio.Song
+import com.asm.tavern.domain.model.audio.SongId
+import com.asm.tavern.domain.model.audio.SongRepository
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
+import org.springframework.beans.factory.annotation.Autowired
+import java.util.stream.StreamSupport
+
+class ModeService {
+
+    private final SongRepository songRegistry
+    private AudioService audioService
+
+    final enum MODE{
+        WEAVE,
+        CATEGORY,
+        DEFAULT
+    }
+
+    private String category
+    private AudioTrack weaveSongTrack
+    MODE mode
+
+    private List<Song> categoryQueue
+
+    ModeService(@Autowired SongRepository songRegistry){
+        this.songRegistry = songRegistry
+        mode = MODE.DEFAULT
+        category = ""
+    }
+
+    void defaultMode() {
+        this.mode = MODE.DEFAULT
+    }
+
+    MODE getMode() {
+        mode
+    }
+
+    String getCategory() {
+        category
+    }
+
+    void setWeave(AudioTrack track){
+        this.weaveSongTrack = track
+        this.setMode(MODE.WEAVE)
+    }
+
+    void setCategory(String category, AudioService audioService) {
+        this.audioService = audioService
+        this.category = category
+        categoryQueue = StreamSupport.stream(songRegistry.getAll().spliterator(), false)
+                .filter(s -> s.category == getCategory())
+                .collect()
+        Collections.shuffle(categoryQueue)
+        this.setMode(MODE.CATEGORY)
+    }
+
+    private void refreshCategoryQueue(){
+        categoryQueue = StreamSupport.stream(songRegistry.getAll().spliterator(), false)
+                .filter(s -> s.category == getCategory())
+                .collect()
+        Collections.shuffle(categoryQueue)
+    }
+
+    AudioTrack getNext(){
+        switch(mode){
+            case MODE.CATEGORY:
+                {
+                    try{
+                        return audioService.getAudioTrack(categoryQueue.pop().uri)
+                    }
+                    catch(NoSuchElementException e){
+                        refreshCategoryQueue()
+                        return audioService.getAudioTrack(categoryQueue.pop().uri)
+                    }
+                }
+            case MODE.WEAVE:
+                return weaveSongTrack
+            default:
+                return null
+        }
+    }
+
+}

--- a/audio/src/main/groovy/com/asm/tavern/discord/audio/TrackScheduler.groovy
+++ b/audio/src/main/groovy/com/asm/tavern/discord/audio/TrackScheduler.groovy
@@ -1,5 +1,6 @@
 package com.asm.tavern.discord.audio
 
+
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer
 import com.sedmelluq.discord.lavaplayer.player.event.AudioEventAdapter
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException
@@ -7,7 +8,6 @@ import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import com.sedmelluq.discord.lavaplayer.track.AudioTrackEndReason
 import net.dv8tion.jda.api.EmbedBuilder
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
-import net.dv8tion.jda.api.interactions.components.*
 import net.dv8tion.jda.api.interactions.components.buttons.Button
 
 import java.time.Duration
@@ -21,6 +21,7 @@ class TrackScheduler extends AudioEventAdapter {
 	private TextChannel textChannel
 	private final int maxRetryCount = 3
 	private int retryCount = 0
+	private ModeService modeService
 
 	/**
 	 * @param player The audio player this scheduler uses
@@ -45,9 +46,7 @@ class TrackScheduler extends AudioEventAdapter {
 	}
 
 	void playNext(AudioTrack track) {
-		// possibly this should just be an error that nothing is currently in the queue and play command should be used instead,
-		// but if nothing is in the queue and you attempt to playNext you probably just want the song to play right?
-		if (!player.startTrack(track, true)) {
+		if (!queue.empty) {
 			// add new song to queue position 0 ie: next
 			BlockingQueue<AudioTrack> modifiedQueue = new LinkedBlockingQueue<>()
 			List<AudioTrack> songList = queue.toList()
@@ -56,20 +55,40 @@ class TrackScheduler extends AudioEventAdapter {
 
 			this.queue = modifiedQueue
 		}
+		else {
+			queue(track)
+		}
+	}
+
+	void forceNext() {
+		if(modeService.mode != null && modeService.mode != ModeService.MODE.DEFAULT) {
+			switch (modeService.mode) {
+				case ModeService.MODE.CATEGORY:
+					if (queue.empty) {
+						AudioTrack modeTrack = modeService.getNext()
+						playNext(modeTrack.makeClone())
+					}
+					break
+				case ModeService.MODE.WEAVE:
+					AudioTrack weaveTrack = modeService.getNext()
+					if (weaveTrack.info.title != track.info.title)
+						playNext(weaveTrack.makeClone())
+					break
+			}
+		}
+		nextTrack()
 	}
 
 	/**
 	 * Start the next track, stopping the current one if it is playing.
 	 */
 	void nextTrack() {
-		// Start the next track, regardless of if something is already playing or not. In case queue was empty, we are
-		// giving null to startTrack, which is a valid argument and will simply stop the player.
 		player.startTrack(queue.poll(), false)
 	}
 
 	void skip(int amount) {
 		(1..<amount).forEach({ _ -> queue.poll()})
-		nextTrack()
+		player.stopTrack()
 	}
 
 	void skipTime(int amount) {
@@ -94,9 +113,9 @@ class TrackScheduler extends AudioEventAdapter {
 		player.setPaused(false)
 	}
 
-    boolean getIsPaused() {
-        player.paused
-    }
+	boolean getIsPaused() {
+		player.paused
+	}
 
 	void shuffle() {
 		// Shuffle and reconstruct the Queue
@@ -112,6 +131,10 @@ class TrackScheduler extends AudioEventAdapter {
 		this.textChannel = textChannel
 	}
 
+	void setModeService(ModeService modeService){
+		this.modeService = modeService
+	}
+
 	BlockingQueue<AudioTrack> getQueue() {
 		queue
 	}
@@ -121,9 +144,42 @@ class TrackScheduler extends AudioEventAdapter {
 	}
 
 	@Override
+	void onTrackStuck(AudioPlayer player, AudioTrack track, long thresholdMs) {
+		player.startTrack(queue.poll(), true)
+	}
+
+	@Override
 	void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
+		if(endReason == AudioTrackEndReason.LOAD_FAILED){
+
+			if(retryCount < 3) {
+				retryCount++
+				textChannel.sendMessage("Failure playing track: " + track.info.title + " attempting to retry. Attempt Number: " + retryCount).queue()
+				player.startTrack(track.makeClone(), false)
+			}
+			else {
+				textChannel.sendMessage("Failed to play track: " + track.info.title + " " + retryCount + " times, track will be skipped. Video may be unavailable."  + retryCount).queue()
+				retryCount = 0
+			}
+		}
+
 		// Only start the next track if the end reason is suitable for it (FINISHED or LOAD_FAILED)
-		if (endReason.mayStartNext) {
+		else if (endReason.mayStartNext || endReason == AudioTrackEndReason.STOPPED){
+			if(modeService.mode != null && modeService.mode != ModeService.MODE.DEFAULT) {
+				switch (modeService.mode) {
+					case ModeService.MODE.CATEGORY:
+						if (queue.empty) {
+							AudioTrack modeTrack = modeService.getNext()
+							playNext(modeTrack.makeClone())
+						}
+						break
+					case ModeService.MODE.WEAVE:
+						AudioTrack weaveTrack = modeService.getNext()
+						if (weaveTrack.info.title != track.info.title)
+							playNext(weaveTrack.makeClone())
+						break
+				}
+			}
 			nextTrack()
 		}
 	}
@@ -141,36 +197,36 @@ class TrackScheduler extends AudioEventAdapter {
 
 		String videoImgUrl = getVideoImageID(track.info.uri.toString())
 		EmbedBuilder eb = new EmbedBuilder()
-		//eb.setTitle(track.info.title, track.info.uri) // large hyperlink
-		eb.setAuthor(track.info.author, track.info.uri) // , videoImgUrl) image for author top left
+		eb.setTitle(track.info.title, track.info.uri) // large hyperlink
+		//eb.setAuthor(track.info.author)//, track.info.uri) // , videoImgUrl) image for author top left
 		//eb.setImage(videoImgUrl) // Bottom large image
 		eb.setThumbnail(videoImgUrl) // Top right corner image
-		eb.setDescription("Now Playing: ${track.info.title}")
+		eb.setDescription("By: ${track.info.author}")
 		eb.addField("Duration:", "${formatTime(Duration.ofMillis(player.playingTrack.position))}/${formatTime(Duration.ofMillis(track.info.length))}", false)
 		eb.setColor(0x5865F2) // blurple
 
 		textChannel.sendMessageEmbeds(eb.build())
-                .setActionRow(
-                        Button.primary("skip", "Skip"),
-						Button.primary("shuffle", "Shuffle"),
-						Button.primary("pause", "Play/Pause"),
-                )
-                .queue()
+			.setActionRow(
+				Button.primary("skip", "Skip"),
+				Button.primary("shuffle", "Shuffle"),
+				Button.primary("pause", "Play/Pause"),
+			)
+			.queue()
 	}
 
 	@Override
 	void onTrackException(AudioPlayer player, AudioTrack track, FriendlyException exception) {
 		// Retry X times.
-		if(retryCount < maxRetryCount)
-		{
-			retryCount++
-			textChannel.sendMessage("Failure playing track: " + track.info.title + " attempting to retry. Attempt Number: " + retryCount).queue()
-			player.startTrack(track.makeClone(), false)
-		}
-		else{
-			textChannel.sendMessage("Failed to play track: " + track.info.title + " " + retryCount + " times, track will be skipped. Video may be unavailable."  + retryCount).queue()
-			retryCount = 0
-		}
+//		if(retryCount < maxRetryCount)
+//		{
+//			retryCount++
+//			textChannel.sendMessage("Failure playing track: " + track.info.title + " attempting to retry. Attempt Number: " + retryCount).queue()
+//			player.startTrack(track.makeClone(), false)
+//		}
+//		else{
+//			textChannel.sendMessage("Failed to play track: " + track.info.title + " " + retryCount + " times, track will be skipped. Video may be unavailable."  + retryCount).queue()
+//			retryCount = 0
+//		}
 	}
 
 }

--- a/buildSrc/src/main/groovy/com.asm.tavern.discord.groovy-common-conventions.gradle
+++ b/buildSrc/src/main/groovy/com.asm.tavern.discord.groovy-common-conventions.gradle
@@ -34,8 +34,9 @@ dependencies {
     compile 'net.dv8tion:JDA:5.0.0-beta.6'
 
     // Logging
-    compile group: 'org.slf4j', name: 'slf4j-api', version: '1.7.30'
-    compile group: 'org.slf4j', name: 'slf4j-ext', version: '1.7.30'
+    compile group: 'org.slf4j', name: 'slf4j-simple', version: '2.0.7'
+    compile group: 'org.slf4j', name: 'slf4j-api', version: '2.0.7'
+    compile group: 'org.slf4j', name: 'slf4j-ext', version: '2.0.7'
 
     // Util
     compile group: 'com.google.guava', name: 'guava', version: '30.1-jre'

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/NowPlayingCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/NowPlayingCommandHandler.groovy
@@ -49,11 +49,11 @@ class NowPlayingCommandHandler implements CommandHandler {
 		if (track) {
 			String videoImgUrl = getVideoImageID(track.info.url.toString())
 			EmbedBuilder eb = new EmbedBuilder()
-			//eb.setTitle(track.info.title, track.info.url.toString()) // large hyperlink
-			eb.setAuthor(track.info.author, track.info.url.toString()) // , videoImgUrl) // image for author top left
+			eb.setTitle(track.info.title, track.info.url.toString()) // large hyperlink
+			//eb.setAuthor(track.info.title, track.info.url.toString()) // , videoImgUrl) // image for author top left
 			//eb.setImage(videoImgUrl) // Bottom large image
 			eb.setThumbnail(videoImgUrl) //Top right corner image
-			eb.setDescription("Now Playing: ${track.info.title}")
+			eb.setDescription("By: ${track.info.author}")
 			eb.addField("Duration:", "${formatTime(track.currentTime)}/${formatTime(track.info.duration)}", false)
 			eb.setColor(0x5865F2) // blurple
 

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PlayModeCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PlayModeCommandHandler.groovy
@@ -1,0 +1,61 @@
+package com.asm.tavern.discord.discord.audio
+
+import com.asm.tavern.domain.model.audio.AudioService
+import com.asm.tavern.domain.model.TavernCommands
+import com.asm.tavern.domain.model.audio.SongService
+import com.asm.tavern.domain.model.audio.SpotifyService
+import com.asm.tavern.domain.model.command.*
+import com.asm.tavern.domain.model.discord.GuildId
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+
+import javax.annotation.Nonnull
+import java.util.stream.StreamSupport
+
+class PlayModeCommandHandler implements CommandHandler{
+    private final SongService songService
+    private final AudioService audioService
+    private final SpotifyService spotifyService
+
+    PlayModeCommandHandler(SongService songService, AudioService audioService) {
+        this.songService = songService
+        this.audioService = audioService
+        this.spotifyService = songService.getSpotifyService()
+    }
+
+    @Override
+    Command getCommand() {
+        TavernCommands.PLAY_MODE
+    }
+
+    @Override
+    boolean supportsUsage(CommandArgumentUsage usage) {
+        true
+    }
+
+    @Override
+    CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
+        if(!message.args.empty){
+            String categoryId = message.args.first()
+            GuildId guildId = new GuildId(event.guild.id)
+
+            if(StreamSupport.stream(songService.getSongRegistry().getAll().spliterator(), false).anyMatch(s -> s.category == categoryId)) {
+                event.getChannel().sendMessage("Tavern will shuffle ${categoryId} songs after the queue is empty.").queue()
+                audioService.setCategory(categoryId)
+                if(audioService.getNowPlaying(guildId) == null){
+                    audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
+                    audioService.forcePlay(event.getChannel().asTextChannel())
+                }
+            }
+            else
+                event.getChannel().sendMessage("No songs from the category: ${categoryId} found.").queue()
+        }
+        else{
+            audioService.clearPlayMode()
+            event.getChannel().sendMessage("Tavern play mode set to default.").queue()
+        }
+
+
+        new CommandResultBuilder().success().build()
+    }
+
+}

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PlayNextCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/PlayNextCommandHandler.groovy
@@ -42,7 +42,7 @@ class PlayNextCommandHandler implements CommandHandler {
                         .forEach(song -> audioService.playNext(event.getChannel().asTextChannel(), song.id.toString()))
 
             }, () -> {
-                event.getChannel().sendMessage("Could not retrieve spotify songs from ${songId}")
+                event.getChannel().sendMessage("Could not retrieve spotify songs from ${songId}").queue()
             })
         }
         else{

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/SkipCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/SkipCommandHandler.groovy
@@ -30,11 +30,11 @@ class SkipCommandHandler implements CommandHandler {
 	CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
 		int skipAmount = message.args[0] ? Integer.parseInt(message.args[0]) : 1
 		GuildId guildId = new GuildId(event.getGuild().getId())
-		String title = audioService.getNowPlaying(guildId).info.title
-		if(skipAmount == 1){
+		String title = audioService.getNowPlaying(guildId) != null ? audioService.getNowPlaying(guildId).info.title : ""
+		if(!title.empty && skipAmount == 1){
 			event.getChannel().sendMessage("Skipping: ${title}").queue()
 		}
-		else{
+		else {
 			event.getChannel().sendMessage("Skipping ${skipAmount} songs").queue()
 		}
 

--- a/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/WeaveSongCommandHandler.groovy
+++ b/discord/src/main/groovy/com/asm/tavern/discord/discord/audio/WeaveSongCommandHandler.groovy
@@ -1,0 +1,66 @@
+package com.asm.tavern.discord.discord.audio
+
+import com.asm.tavern.domain.model.audio.AudioService
+import com.asm.tavern.domain.model.TavernCommands
+import com.asm.tavern.domain.model.audio.SongService
+import com.asm.tavern.domain.model.audio.SpotifyService
+import com.asm.tavern.domain.model.command.*
+import net.dv8tion.jda.api.events.message.MessageReceivedEvent
+
+import javax.annotation.Nonnull
+
+class WeaveSongCommandHandler implements CommandHandler{
+    private final SongService songService
+    private final AudioService audioService
+    private final SpotifyService spotifyService
+
+    WeaveSongCommandHandler(SongService songService, AudioService audioService) {
+        this.songService = songService
+        this.audioService = audioService
+        this.spotifyService = songService.getSpotifyService()
+    }
+
+    @Override
+    Command getCommand() {
+        TavernCommands.WEAVE
+    }
+
+    @Override
+    boolean supportsUsage(CommandArgumentUsage usage) {
+        true
+    }
+
+    @Override
+    CommandResult handle(@Nonnull MessageReceivedEvent event, CommandMessage message) {
+        if(!message.args.empty){
+            String songId = message.args.first()
+            //Check for spotify link here so we can play multiple times for a playlist from spotify
+            if(songId.contains(spotifyService.URI_CHECK_STRING)){
+                spotifyService.getListOfSongsFromURL(songId).ifPresentOrElse( songList -> {
+                    audioService.join(event.getMember().getVoiceState(), event.getGuild().getAudioManager())
+                    songList.stream().findFirst().ifPresent(song -> audioService.setWeaveAudio(song.id.toString()))
+
+                }, () -> {
+                    event.getChannel().sendMessage("Could not retrieve spotify songs from ${songId}").queue()
+                })
+            }
+            else{
+                songService.songFromString(songId).ifPresentOrElse(song -> {
+                    audioService.setWeaveAudio(song.uri)
+                    event.getChannel().sendMessage("Tavern will weave ${song.id} after each song.").queue()
+                }, () -> {
+                    // this will search the message on youtube
+                    audioService.setWeaveAudio(message.args.join(" "))
+                    event.getChannel().sendMessage("Tavern will weave ${message.args.join(" ")} after each song.").queue()
+                })
+            }
+        }
+        else{
+            audioService.clearPlayMode()
+            event.getChannel().sendMessage("Tavern will stop weaving after each song.").queue()
+        }
+
+        new CommandResultBuilder().success().build()
+    }
+
+}

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -4,5 +4,6 @@ plugins {
 
 dependencies {
     implementation project(':utilities')
-    implementation 'org.json:json:20220924'
+    implementation 'org.json:json:20230227'
+    implementation 'dev.arbjerg:lavaplayer:2.0.0'
 }

--- a/domain/src/main/groovy/com/asm/tavern/domain/model/TavernCommands.groovy
+++ b/domain/src/main/groovy/com/asm/tavern/domain/model/TavernCommands.groovy
@@ -88,6 +88,21 @@ class TavernCommands {
 				.add(argument('song', 'the youtube url or song id').example("https://www.youtube.com/watch?v=dQw4w9WgXcQ")))
 			.build()
 
+	static final Command WEAVE = command('weave', 'Sets tavern to weave mode for a given song')
+			.tag(Tags.MUSIC)
+			.add(usage('default', 'Turns off Weave Mode'))
+			.add(usage('song', 'Song to be weaved into the queue')
+					.varArgs()
+					.add(argument('song', 'the youtube url or song id').example("https://www.youtube.com/watch?v=dQw4w9WgXcQ")))
+			.build()
+
+	static final Command PLAY_MODE = command('pm', 'Sets tavern to play mode for given category')
+			.tag(Tags.MUSIC)
+			.add(usage('default', 'Turns off modes'))
+			.add(usage('category', 'Category to be shuffled at the end of the queue')
+					.add(argument('category', 'the category string').example('elevator')))
+			.build()
+
 	static final Command NOW_PLAYING = command('np', 'Get the current playing track')
 			.tag(Tags.MUSIC)
 			.add(usage('default', 'Get the current playing track'))
@@ -111,7 +126,8 @@ class TavernCommands {
 	static final Command SKIP = command('skip', 'Skip the current track')
 			.tag(Tags.MUSIC)
 			.add(usage('default', 'Skip the current track'))
-			.add(usage('skip amount', 'Skip an amount of songs').add(argument('amount', 'The amount of songs to skip').example('5')))
+			.add(usage('skip amount', 'Skip an amount of songs')
+					.add(argument('amount', 'The amount of songs to skip').example('5')))
 			.build()
 
 	static final Command SKIP_TIME = command('st', 'Skip seconds from playing track')
@@ -154,7 +170,7 @@ class TavernCommands {
 
 	static class SongsUsages {
 		static final CommandArgumentUsage DEFAULT = usage('default', 'List songs').build()
-		static final CommandArgumentUsage ADD_WITH_CATEGORY = usage('add', 'Register a new song with category')
+		static final CommandArgumentUsage ADD_WITH_CATEGORY = usage('add ', 'Register a new song with category')
 				.add(argument('add', 'required').example('add'))
 				.add(argument('id', 'The id to register the song as').example('chuchu'))
 				.add(argument('url', 'The url of the song to register').example('https://www.youtube.com/watch?v=5d32-RnUlAA'))
@@ -162,7 +178,7 @@ class TavernCommands {
 				.requireRole(Roles.DJ)
 				.build()
 
-		static final CommandArgumentUsage ADD = usage('add', 'Register a new song.')
+		static final CommandArgumentUsage ADD = usage('add', 'Register a new song')
 				.add(argument('add', 'required').example('add'))
 				.add(argument('id', 'The id to register the song as').example('chuchu'))
 				.add(argument('url', 'The url of the song to register').example('https://www.youtube.com/watch?v=5d32-RnUlAA'))
@@ -171,7 +187,7 @@ class TavernCommands {
 
 		static final CommandArgumentUsage REMOVE = usage('remove', 'Remove a registered song')
 				.add(argument('remove', 'required').example('remove'))
-				.add(argument('id', 'The id of the song to remove').example('chuchu'))
+				.add(argument('id', 'The id of the song to remove').example('chchu'))
 				.requireRole(Roles.DJ)
 				.build()
 	}

--- a/domain/src/main/groovy/com/asm/tavern/domain/model/audio/AudioService.groovy
+++ b/domain/src/main/groovy/com/asm/tavern/domain/model/audio/AudioService.groovy
@@ -2,6 +2,7 @@ package com.asm.tavern.domain.model.audio
 
 import com.asm.tavern.domain.model.discord.GuildId
 import com.asm.tavern.domain.model.discord.VoiceChannelId
+import com.sedmelluq.discord.lavaplayer.track.AudioTrack
 import net.dv8tion.jda.api.entities.Guild
 import net.dv8tion.jda.api.entities.GuildVoiceState
 import net.dv8tion.jda.api.entities.channel.concrete.TextChannel
@@ -21,7 +22,7 @@ interface AudioService {
 
 	void skip(GuildId guildId, int amount)
 
-	void skipTime(GuildId guildid, int amount)
+	void skipTime(GuildId guildId, int amount)
 
 	void stop(GuildId guildId)
 
@@ -37,10 +38,24 @@ interface AudioService {
 
 	void playNext(TextChannel textChannel, String searchString)
 
+	void setWeaveAudio(String searchString)
+
+	void setWeaveAudio(URI song)
+
+	void setCategory(String category)
+
+	void clearPlayMode()
+
+	void forcePlay(TextChannel textChannel)
+
 	List<AudioTrackInfo> getQueue(GuildId guildId)
 
 	ActiveAudioTrack getNowPlaying(GuildId guildId)
 
 	boolean getIsPaused(GuildId guildId)
+
+	AudioTrack getAudioTrack(String searchString)
+
+	AudioTrack getAudioTrack(URI uri)
 
 }


### PR DESCRIPTION
Mode service added to manage retrieving the next song during a custom mode, like weave or category. Weave will play the selected song after each song

Category will play the songs from a given category shuffled and repeated while the queue is empty.

Skip Time addition for skip seconds out of a song

Updated nowplaying and trackscheduler embed builders to more correctly display song titles and author

new commands:
weave songName
st secondToSkip
pm songCategory